### PR TITLE
fix: wrong offset applied to Serverbound packets

### DIFF
--- a/src/main/java/org/oryxel/gfp/packets/client/ClientPlayerAction.java
+++ b/src/main/java/org/oryxel/gfp/packets/client/ClientPlayerAction.java
@@ -1,6 +1,9 @@
 package org.oryxel.gfp.packets.client;
 
-import org.cloudburstmc.protocol.bedrock.data.*;
+import org.cloudburstmc.protocol.bedrock.data.LevelEvent;
+import org.cloudburstmc.protocol.bedrock.data.PlayerActionType;
+import org.cloudburstmc.protocol.bedrock.data.PlayerAuthInputData;
+import org.cloudburstmc.protocol.bedrock.data.PlayerBlockActionData;
 import org.cloudburstmc.protocol.bedrock.packet.LevelEventPacket;
 import org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.player.GameMode;
@@ -8,6 +11,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.entity.player.PlayerAction;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.level.ClientboundBlockDestructionPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundPickItemFromBlockPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundSetCommandBlockPacket;
+import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundSetJigsawBlockPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.inventory.ServerboundSetStructureBlockPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.level.ServerboundBlockEntityTagQueryPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.level.ServerboundJigsawGeneratePacket;
@@ -48,39 +52,39 @@ public class ClientPlayerAction implements JavaPacketListener, BedrockPacketList
         }
 
         if (event.getPacket() instanceof ServerboundBlockEntityTagQueryPacket packet) {
-            event.setPacket(new ServerboundBlockEntityTagQueryPacket(packet.getTransactionId(), packet.getPosition().sub(session.getOffset())));
+            event.setPacket(new ServerboundBlockEntityTagQueryPacket(packet.getTransactionId(), packet.getPosition().add(session.getOffset())));
         }
 
         if (event.getPacket() instanceof ServerboundJigsawGeneratePacket packet) {
-            event.setPacket(new ServerboundJigsawGeneratePacket(packet.getPosition().sub(session.getOffset()), packet.getLevels(), packet.isKeepJigsaws()));
+            event.setPacket(new ServerboundJigsawGeneratePacket(packet.getPosition().add(session.getOffset()), packet.getLevels(), packet.isKeepJigsaws()));
         }
 
         if (event.getPacket() instanceof ServerboundPickItemFromBlockPacket packet) {
-            event.setPacket(new ServerboundPickItemFromBlockPacket(packet.getPos().sub(session.getOffset()), packet.isIncludeData()));
+            event.setPacket(new ServerboundPickItemFromBlockPacket(packet.getPos().add(session.getOffset()), packet.isIncludeData()));
         }
 
         if (event.getPacket() instanceof ServerboundSetCommandBlockPacket packet) {
-            event.setPacket(new ServerboundSetCommandBlockPacket(packet.getPosition().sub(session.getOffset()), packet.getCommand(),
+            event.setPacket(new ServerboundSetCommandBlockPacket(packet.getPosition().add(session.getOffset()), packet.getCommand(),
                     packet.getMode(), packet.isDoesTrackOutput(), packet.isConditional(), packet.isAutomatic()));
         }
 
-        // A bit tricky so this is a TODO for now since net.kyori.adventure.key.Key is relocated.
-//        if (event.getPacket() instanceof ServerboundSetJigsawBlockPacket packet) {
-//            event.setPacket(new ServerboundSetJigsawBlockPacket(packet.getPosition().sub(session.getOffset()),
-//                    packet.getName(), ));
-//        }
+        if (event.getPacket() instanceof ServerboundSetJigsawBlockPacket packet) {
+            event.setPacket(new ServerboundSetJigsawBlockPacket(
+                    packet.getPosition().add(session.getOffset()), packet.getName(), packet.getTarget(), packet.getPool(),
+                    packet.getFinalState(), packet.getJointType(), packet.getSelectionPriority(), packet.getPlacementPriority()));
+        }
 
         if (event.getPacket() instanceof ServerboundSetStructureBlockPacket packet) {
             event.setPacket(new ServerboundSetStructureBlockPacket(
-                    packet.getPosition().sub(session.getOffset()), packet.getAction(), packet.getMode(),
-                    packet.getName(), packet.getOffset(), packet.getSize(),  packet.getMirror(),
+                    packet.getPosition().add(session.getOffset()), packet.getAction(), packet.getMode(),
+                    packet.getName(), packet.getOffset(), packet.getSize(), packet.getMirror(),
                     packet.getRotation(), packet.getMetadata(), packet.getIntegrity(), packet.getSeed(),
                     packet.isIgnoreEntities(), packet.isShowAir(), packet.isShowBoundingBox(), packet.isStrict()
             ));
         }
 
         if (event.getPacket() instanceof ServerboundSignUpdatePacket packet) {
-            event.setPacket(new ServerboundSignUpdatePacket(packet.getPosition().sub(session.getOffset()), packet.getLines(), packet.isFrontText()));
+            event.setPacket(new ServerboundSignUpdatePacket(packet.getPosition().add(session.getOffset()), packet.getLines(), packet.isFrontText()));
         }
     }
 


### PR DESCRIPTION
For Serverbound packets, I think we should use `add()` when applying the offset
About `ServerboundSetJigsawBlockPacket` not sure what the comment means, but it works fine after testing