### PR TITLE
Fixes extension not loading on Geyser-Velocity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,16 +23,18 @@ dependencies {
     compileOnly("org.geysermc.geyser:core:2.7.1-SNAPSHOT") {
         exclude group: "com.google.code.gson", module: "gson"
     }
-    compileOnly("it.unimi.dsi:fastutil:8.5.15")
+
+    implementation("it.unimi.dsi:fastutil:8.5.15")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2")
+
     compileOnly("org.projectlombok:lombok:1.18.36")
     annotationProcessor("org.projectlombok:lombok:1.18.36")
-
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2")
 }
 
 shadowJar {
     relocate 'org.yaml.snakeyaml', 'org.oryxel.gfp.shaded.snakeyaml'
     relocate 'com.fasterxml', 'org.oryxel.gfp.shaded.fasterxml'
+    relocate 'it.unimi.dsi.fastutil', 'org.oryxel.gfp.shaded.fastutil'
 }
 
 def targetJavaVersion = 17


### PR DESCRIPTION
```[11:01:37] [GeyserServerChild-4-1/WARN] [geyser]: Extension GeyserFloatingPoints. loads class it.unimi.dsi.fastutil.longs.Long2ObjectMap from an external source. This can change at any time and break the extension, additionally to potentially causing unexpected behaviour! [11:01:37] [GeyserServerChild-4-1/ERROR] ```

Fixes this error when loading the extension on Geyser-Velocity, FastUtil was not being shadowed correctly.

Fixes #5 