### PR TITLE
Add permission node to control position command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Workaround to fix floating-point precision on Bedrock when at high coordinate.
 - Simply works by spoofing position on Bedrock player side, making it seems like they're still close to 0 0 0 coordinate.
 
 ## Commands
-- `/geyserfloatingpoints position` - Toggle on/off actionbar that show your real position.
+- `/geyserfloatingpoints position` - Toggle on/off actionbar that show your real position. Permission: `geyserfloatingpoints.position`
 
 ## Drawbacks
 - You won't be able to see your real position since your position is always spoofed.

--- a/src/main/java/org/oryxel/gfp/geyser/GFPExtension.java
+++ b/src/main/java/org/oryxel/gfp/geyser/GFPExtension.java
@@ -10,6 +10,7 @@ import org.geysermc.geyser.api.event.lifecycle.GeyserDefineCommandsEvent;
 import org.geysermc.geyser.api.event.lifecycle.GeyserPostInitializeEvent;
 import org.geysermc.geyser.api.event.lifecycle.GeyserShutdownEvent;
 import org.geysermc.geyser.api.extension.Extension;
+import org.geysermc.geyser.api.util.TriState;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.mcprotocollib.protocol.data.game.chunk.DataPalette;
 import org.oryxel.gfp.GeyserFloatingPoints;
@@ -59,13 +60,13 @@ public class GFPExtension implements Extension {
     public void onDefineCommands(GeyserDefineCommandsEvent event) {
         event.register(Command.builder(this).source(CommandSource.class)
                 .name("position")
-                .playerOnly(true).bedrockOnly(true)
+                .playerOnly(true).bedrockOnly(true).permission("geyserfloatingpoints.position", TriState.TRUE)
                 .description("Toggle off/on title to show your real position, won't show anything if your current position is in fact real.")
                 .executor((source, cmd, args) -> {
                     if (source.connection() instanceof GeyserSession session) {
                         if (showPositions.contains(session)) {
                             showPositions.remove(session);
-                            source.sendMessage("Stop showing your position!");
+                            source.sendMessage("Stopped showing your position!");
                         } else {
                             showPositions.add(session);
                             source.sendMessage("Now showing your position!");


### PR DESCRIPTION
Great extension! 😁 

Added a permission node so the position command can be turned off. It is still defaulted to TRUE, so this will not change your existing behavior.