### PR TITLE
Hide coordinates if we are rewriting them

### DIFF
--- a/src/main/java/oxy/geyser/fp/network/wrapper/UpstreamHandlerWrapper.java
+++ b/src/main/java/oxy/geyser/fp/network/wrapper/UpstreamHandlerWrapper.java
@@ -29,11 +29,13 @@ public class UpstreamHandlerWrapper extends UpstreamSession {
             GeyserUtil.wrapAroundSessionAdaptor(user);
         }
 
+        user.onPacketSent(packet);
         prevSession.sendPacket(packet);
     }
 
     @Override
     public void sendPacketImmediately(@NonNull BedrockPacket packet) {
+        user.onPacketSent(packet);
         prevSession.sendPacketImmediately(packet);
     }
 
@@ -42,3 +44,4 @@ public class UpstreamHandlerWrapper extends UpstreamSession {
         return prevSession.getProtocolVersion();
     }
 }
+

--- a/src/main/java/oxy/geyser/fp/network/wrapper/UpstreamHandlerWrapper.java
+++ b/src/main/java/oxy/geyser/fp/network/wrapper/UpstreamHandlerWrapper.java
@@ -58,7 +58,6 @@ public class UpstreamHandlerWrapper extends UpstreamSession {
                 if (!SHOW_COORDINATES_GAME_RULE.equals(rule.getName())) {
                     continue;
                 }
-
                 gameRulesPacket.getGameRules().set(i, new GameRuleData<>(SHOW_COORDINATES_GAME_RULE, false));
                 return;
             }

--- a/src/main/java/oxy/geyser/fp/network/wrapper/UpstreamHandlerWrapper.java
+++ b/src/main/java/oxy/geyser/fp/network/wrapper/UpstreamHandlerWrapper.java
@@ -1,12 +1,17 @@
 package oxy.geyser.fp.network.wrapper;
 
 import lombok.NonNull;
+import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
+import org.cloudburstmc.protocol.bedrock.data.GameRuleData;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+import org.cloudburstmc.protocol.bedrock.packet.GameRulesChangedPacket;
 import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
 import org.geysermc.geyser.session.UpstreamSession;
 import oxy.geyser.fp.session.GeyserFPUser;
 import oxy.geyser.fp.util.GeyserUtil;
+
+import static oxy.geyser.fp.session.GeyserFPUser.SHOW_COORDINATES_GAME_RULE;
 
 public class UpstreamHandlerWrapper extends UpstreamSession {
     private final GeyserFPUser user;
@@ -29,13 +34,12 @@ public class UpstreamHandlerWrapper extends UpstreamSession {
             GeyserUtil.wrapAroundSessionAdaptor(user);
         }
 
-        user.onPacketSent(packet);
+        hideCoordinatesIfOffset(packet);
         prevSession.sendPacket(packet);
     }
 
     @Override
     public void sendPacketImmediately(@NonNull BedrockPacket packet) {
-        user.onPacketSent(packet);
         prevSession.sendPacketImmediately(packet);
     }
 
@@ -43,5 +47,21 @@ public class UpstreamHandlerWrapper extends UpstreamSession {
     public int getProtocolVersion() {
         return prevSession.getProtocolVersion();
     }
-}
 
+    private void hideCoordinatesIfOffset(BedrockPacket packet) {
+        if (packet instanceof GameRulesChangedPacket gameRulesPacket) {
+            if (user.offset().equals(Vector3i.ZERO)) {
+                return;
+            }
+            for (int i = 0; i < gameRulesPacket.getGameRules().size(); i++) {
+                GameRuleData<?> rule = gameRulesPacket.getGameRules().get(i);
+                if (!SHOW_COORDINATES_GAME_RULE.equals(rule.getName())) {
+                    continue;
+                }
+
+                gameRulesPacket.getGameRules().set(i, new GameRuleData<>(SHOW_COORDINATES_GAME_RULE, false));
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/oxy/geyser/fp/session/GeyserFPUser.java
+++ b/src/main/java/oxy/geyser/fp/session/GeyserFPUser.java
@@ -105,6 +105,7 @@ public class GeyserFPUser {
 
     private boolean shouldShowCoordinates() {
         return this.offset.equals(Vector3i.ZERO)
+                // From https://github.com/GeyserMC/Geyser/blob/fc2681ada4e0b5e344d64927f978ec7ac751fea5/core/src/main/java/org/geysermc/geyser/session/cache/PreferencesCache.java#L78
                 && !session.isReducedDebugInfo()
                 && session.getGeyser().config().gameplay().showCoordinates()
                 && session.getPreferencesCache().isPrefersShowCoordinates();

--- a/src/main/java/oxy/geyser/fp/session/GeyserFPUser.java
+++ b/src/main/java/oxy/geyser/fp/session/GeyserFPUser.java
@@ -9,6 +9,9 @@ import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.packet.MovePlayerPacket;
 import org.geysermc.geyser.entity.EntityDefinitions;
 import org.geysermc.geyser.entity.type.BoatEntity;
+import org.cloudburstmc.protocol.bedrock.data.GameRuleData;
+import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+import org.cloudburstmc.protocol.bedrock.packet.GameRulesChangedPacket;
 import org.geysermc.geyser.entity.type.Entity;
 import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
@@ -25,6 +28,10 @@ import java.util.Collection;
 
 @RequiredArgsConstructor
 public class GeyserFPUser {
+    private boolean geyserShowCoordinates = true;
+    private boolean currentlyHidingCoordinates = false;
+    private static final String SHOW_COORDINATES_GAME_RULE = "showcoordinates";
+
     private final GeyserSession session;
     public GeyserSession session() {
         return session;
@@ -99,5 +106,37 @@ public class GeyserFPUser {
 
         this.offset = offset;
         chunkCache.sendChunksWithOffset();
+        updateCoordinatesGameRule();
+    }
+
+    public void onPacketSent(BedrockPacket packet) {
+        if (packet instanceof GameRulesChangedPacket gameRulesPacket) {
+            for (int i = 0; i < gameRulesPacket.getGameRules().size(); i++) {
+                GameRuleData<?> rule = gameRulesPacket.getGameRules().get(i);
+                if (!rule.getName().equals(SHOW_COORDINATES_GAME_RULE)) {
+                    continue;
+                }
+                if (rule.getValue() instanceof Boolean bool && !currentlyHidingCoordinates) {
+                    geyserShowCoordinates = bool;
+                }
+                if (currentlyHidingCoordinates) {
+                    gameRulesPacket.getGameRules().set(i, new GameRuleData<>(SHOW_COORDINATES_GAME_RULE, false));
+                }
+                return;
+            }
+        }
+    }
+
+    private void updateCoordinatesGameRule() {
+        boolean shouldHide = !this.offset.equals(Vector3i.ZERO);
+        if (this.currentlyHidingCoordinates == shouldHide) {
+            return;
+        }
+        this.currentlyHidingCoordinates = shouldHide;
+
+        GameRulesChangedPacket packet = new GameRulesChangedPacket();
+        packet.getGameRules().add(new GameRuleData<>(SHOW_COORDINATES_GAME_RULE, geyserShowCoordinates && !shouldHide));
+        session.sendUpstreamPacket(packet);
     }
 }
+

--- a/src/main/java/oxy/geyser/fp/session/GeyserFPUser.java
+++ b/src/main/java/oxy/geyser/fp/session/GeyserFPUser.java
@@ -1,19 +1,10 @@
 package oxy.geyser.fp.session;
 
-import it.unimi.dsi.fastutil.objects.ObjectCollection;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.cloudburstmc.math.vector.Vector2d;
-import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
-import org.cloudburstmc.protocol.bedrock.packet.MovePlayerPacket;
-import org.geysermc.geyser.entity.EntityDefinitions;
-import org.geysermc.geyser.entity.type.BoatEntity;
-import org.cloudburstmc.protocol.bedrock.data.GameRuleData;
-import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
-import org.cloudburstmc.protocol.bedrock.packet.GameRulesChangedPacket;
 import org.geysermc.geyser.entity.type.Entity;
-import org.geysermc.geyser.entity.type.player.PlayerEntity;
 import org.geysermc.geyser.entity.type.player.SessionPlayerEntity;
 import org.geysermc.geyser.session.GeyserSession;
 import org.geysermc.geyser.session.cache.EntityCache;
@@ -28,9 +19,7 @@ import java.util.Collection;
 
 @RequiredArgsConstructor
 public class GeyserFPUser {
-    private boolean geyserShowCoordinates = true;
-    private boolean currentlyHidingCoordinates = false;
-    private static final String SHOW_COORDINATES_GAME_RULE = "showcoordinates";
+    public static final String SHOW_COORDINATES_GAME_RULE = "showcoordinates";
 
     private final GeyserSession session;
     public GeyserSession session() {
@@ -104,39 +93,20 @@ public class GeyserFPUser {
         } catch (Exception ignored) {
         }
 
+        boolean wasHidingCoordinates = !this.offset.equals(Vector3i.ZERO);
         this.offset = offset;
         chunkCache.sendChunksWithOffset();
-        updateCoordinatesGameRule();
-    }
 
-    public void onPacketSent(BedrockPacket packet) {
-        if (packet instanceof GameRulesChangedPacket gameRulesPacket) {
-            for (int i = 0; i < gameRulesPacket.getGameRules().size(); i++) {
-                GameRuleData<?> rule = gameRulesPacket.getGameRules().get(i);
-                if (!rule.getName().equals(SHOW_COORDINATES_GAME_RULE)) {
-                    continue;
-                }
-                if (rule.getValue() instanceof Boolean bool && !currentlyHidingCoordinates) {
-                    geyserShowCoordinates = bool;
-                }
-                if (currentlyHidingCoordinates) {
-                    gameRulesPacket.getGameRules().set(i, new GameRuleData<>(SHOW_COORDINATES_GAME_RULE, false));
-                }
-                return;
-            }
+        boolean shouldHideCoordinates = !this.offset.equals(Vector3i.ZERO);
+        if (wasHidingCoordinates != shouldHideCoordinates) {
+            session.sendGameRule(SHOW_COORDINATES_GAME_RULE, shouldShowCoordinates());
         }
     }
 
-    private void updateCoordinatesGameRule() {
-        boolean shouldHide = !this.offset.equals(Vector3i.ZERO);
-        if (this.currentlyHidingCoordinates == shouldHide) {
-            return;
-        }
-        this.currentlyHidingCoordinates = shouldHide;
-
-        GameRulesChangedPacket packet = new GameRulesChangedPacket();
-        packet.getGameRules().add(new GameRuleData<>(SHOW_COORDINATES_GAME_RULE, geyserShowCoordinates && !shouldHide));
-        session.sendUpstreamPacket(packet);
+    private boolean shouldShowCoordinates() {
+        return this.offset.equals(Vector3i.ZERO)
+                && !session.isReducedDebugInfo()
+                && session.getGeyser().config().gameplay().showCoordinates()
+                && session.getPreferencesCache().isPrefersShowCoordinates();
     }
 }
-


### PR DESCRIPTION
If coordinates are sent in geyser config, hide their display when we are spoofing coordinates to the user to avoid confusion.
I have tested this code briefly on geyser spigot and it seems to work.